### PR TITLE
サインアウト機能を実装

### DIFF
--- a/src/app/(mypage)/mypage/_components/MyPageLayout.tsx
+++ b/src/app/(mypage)/mypage/_components/MyPageLayout.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useRouter } from 'next/navigation'
+import { toast } from 'react-toastify'
 
 import { signOut } from '@/app/_utils/auth/signOut'
 
@@ -7,7 +8,7 @@ import { MyPageHeader } from './MyPageHeader'
 import { MyPageMenu } from './MyPageMenu'
 import { MyProfileHeader } from './MyProfileHeader'
 
-export default function MyPageLayout() {
+export const MyPageLayout = () => {
   const router = useRouter()
 
   // ナビゲーションの処理（仮）
@@ -20,7 +21,10 @@ export default function MyPageLayout() {
   const handleLogout = async () => {
     const result = await signOut()
     if (result === null) {
+      toast.success('ログアウトしました')
       router.replace('/login')
+    } else {
+      toast.error(`ログアウトエラー: ${result}`)
     }
   }
 

--- a/src/app/(mypage)/mypage/page.tsx
+++ b/src/app/(mypage)/mypage/page.tsx
@@ -1,4 +1,4 @@
-import MyPageLayout from './_components/MyPageLayout'
+import { MyPageLayout } from './_components/MyPageLayout'
 
 export default function MypagePage() {
   return <MyPageLayout />

--- a/src/app/_utils/auth/signOut.ts
+++ b/src/app/_utils/auth/signOut.ts
@@ -1,5 +1,3 @@
-import { toast } from 'react-toastify'
-
 import { supabase } from '@/app/_lib/supabaseClient'
 
 export const signOut = async (): Promise<string | null> => {
@@ -10,7 +8,6 @@ export const signOut = async (): Promise<string | null> => {
       throw new Error(error.message)
     }
 
-    toast.success('ログアウトしました')
     return null
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : '予期しないエラーです'


### PR DESCRIPTION
## 実装内容
**signOut関数の追加** (`src/app/_utils/auth/signOut.ts`)
- Supabase認証からのサインアウト処理
- 成功・失敗時のトースト通知

**MyPageLayoutの更新** (`src/app/(mypage)/mypage/_components/MyPageLayout.tsx`)
- ログアウトボタンのクリックハンドラー実装
- サインアウト成功時の`/login`へのリダイレクト
- useRouterフックの追加

## テスト
- [ ] マイページでログアウトボタンをクリック
- [ ] ログアウト成功のトースト通知が表示される
- [ ] `/login`ページにリダイレクトされる
- [ ] ブラウザのCookieからセッション情報が削除される