### PR TITLE
chore(tz): タイムゾーン実装を TZDateMini ラッパーに統一（直 import 廃止）

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -51,8 +51,30 @@
         "ignoreDeclarationSort": true,
         "ignoreMemberSort": false
       }
+    ],
+
+    // --- TZDate/TZDateMini の直 import を禁止（ラッパー経由に統一） ---
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "@date-fns/tz",
+            "message": "TZDate / TZDateMini は '@/app/_utils/tz' からのみ import してください。"
+          }
+        ]
+      }
     ]
   },
+  "overrides": [
+    {
+      // ラッパー自身は例外にする
+      "files": ["**/src/app/_utils/tz.ts"],
+      "rules": {
+        "no-restricted-imports": "off"
+      }
+    }
+  ],
   "settings": {
     "react": { "version": "detect" }
   }

--- a/src/app/_utils/jstToUtcRange.ts
+++ b/src/app/_utils/jstToUtcRange.ts
@@ -1,13 +1,17 @@
-import { TZDate } from '@date-fns/tz'
 import { addDays, addWeeks, startOfDay, startOfWeek } from 'date-fns'
 
+import { TZ, TZDate, toUTCDate } from '@/app/_utils/tz'
+
 export const jstToUtcRange = (now: Date, kind: 'day' | 'week') => {
-  const jstNow = new TZDate(now, 'Asia/Tokyo')
+  const jstNow = new TZDate(now, TZ)
+
   if (kind === 'day') {
     const start = startOfDay(jstNow)
-    return { utcStart: new Date(start), utcEnd: new Date(addDays(start, 1)) }
+    const end = addDays(start, 1)
+    return { utcStart: toUTCDate(start), utcEnd: toUTCDate(end) }
   } else {
-    const start = startOfWeek(jstNow, { weekStartsOn: 0 })
-    return { utcStart: new Date(start), utcEnd: new Date(addWeeks(start, 1)) }
+    const start = startOfWeek(jstNow, { weekStartsOn: 0 }) // JSTで日曜始まり
+    const end = addWeeks(start, 1)
+    return { utcStart: toUTCDate(start), utcEnd: toUTCDate(end) }
   }
 }

--- a/src/app/_utils/streakCalculator.ts
+++ b/src/app/_utils/streakCalculator.ts
@@ -2,13 +2,16 @@
  * 学習記録の連続日数を計算するユーティリティ関数
  */
 
-import { TZDate } from '@date-fns/tz'
 import { startOfDay, subDays } from 'date-fns'
+
+import { TZ, TZDate } from '@/app/_utils/tz' // ← ラッパー経由に変更
 
 const normalizeDate = (date: Date): Date => {
   // 日本時間（JST）で日付の開始時刻に正規化
-  const jstDate = new TZDate(date, 'Asia/Tokyo')
-  return startOfDay(jstDate)
+  const jstDate = new TZDate(date, TZ)
+  const start = startOfDay(jstDate)
+  // UTC の epoch を保持したまま通常の Date に戻す
+  return new Date(start.getTime())
 }
 
 const deduplicateAndSortDates = (dates: Date[]): Date[] => {
@@ -37,13 +40,14 @@ export const calculateStreak = (learningDates: Date[]): number => {
   )
   if (daysDiff > 1) return 0
 
-  let currentDate = new TZDate(latestRecordDate, 'Asia/Tokyo')
+  // JST の日付で1日ずつ遡るために TZDate を利用
+  let currentDate = new TZDate(latestRecordDate, TZ)
   let streakCount = 0
 
   for (let i = 0; i < uniqueDates.length; i++) {
     if (uniqueDates[i].getTime() === currentDate.getTime()) {
       streakCount++
-      currentDate = new TZDate(subDays(currentDate, 1), 'Asia/Tokyo')
+      currentDate = new TZDate(subDays(currentDate, 1), TZ)
     } else {
       break
     }

--- a/src/app/_utils/studyTimeHelpers.ts
+++ b/src/app/_utils/studyTimeHelpers.ts
@@ -1,15 +1,13 @@
-// src/app/_utils/studyTimeHelpers.ts
-import { TZDateMini } from '@date-fns/tz'
+import { TZ, TZDate, toUTCDate } from '@/app/_utils/tz'
 
-const ZONE = 'Asia/Tokyo' as const
 const DAY_MS = 86_400_000
 
 /**
  * JST の“今日 00:00”を UTC の Date で返す
  */
 function jstMidnightUtc(base: Date = new Date()): Date {
-  const wall = new TZDateMini(base, ZONE) // JSTの壁時計
-  const jstMidnight = new TZDateMini(
+  const wall = new TZDate(base, TZ) // JST の壁時計
+  const jstMidnight = new TZDate(
     wall.getFullYear(),
     wall.getMonth(),
     wall.getDate(),
@@ -17,10 +15,10 @@ function jstMidnightUtc(base: Date = new Date()): Date {
     0,
     0,
     0,
-    ZONE,
+    TZ,
   )
-  // TZDateMiniのgetTime()は、そのJST壁時計時刻が実際に対応するUTCのエポックms
-  return new Date(jstMidnight.getTime())
+  // JST 壁時計の 00:00 に対応する実 UTC を返す
+  return toUTCDate(jstMidnight)
 }
 
 /**
@@ -41,7 +39,7 @@ export function getWeekUtcRange(base: Date = new Date()): { start: Date; end: Da
 export function getStartOfWeek(date: Date = new Date()): Date {
   // 今日(JST)の00:00(UTC)を起点に、JSTの曜日(0:日〜6:土)だけ戻る
   const todayJstStartUtc = jstMidnightUtc(date)
-  const dow = new TZDateMini(todayJstStartUtc, ZONE).getDay() // JSTの曜日
+  const dow = new TZDate(todayJstStartUtc, TZ).getDay() // JSTの曜日
   const weekStartUtc = new Date(todayJstStartUtc.getTime() - dow * DAY_MS)
   return weekStartUtc
 }

--- a/src/app/_utils/tz.ts
+++ b/src/app/_utils/tz.ts
@@ -1,0 +1,8 @@
+// 既存コードの呼び名を "TZDate" に統一して使う方針
+export { TZDateMini as TZDate } from '@date-fns/tz'
+
+// 既定タイムゾーン（JST）
+export const TZ = 'Asia/Tokyo' as const
+
+// Prisma など UTC Date が必要な I/O で使うヘルパ
+export const toUTCDate = (tzLike: { getTime: () => number }) => new Date(tzLike.getTime())

--- a/src/app/api/ranking/_server/streak.ts
+++ b/src/app/api/ranking/_server/streak.ts
@@ -1,9 +1,8 @@
 'use server'
 
-import { TZDateMini } from '@date-fns/tz'
-
 import { prisma } from '@/app/_lib/prisma'
 import { calculateStreak } from '@/app/_utils/streakCalculator'
+import { TZ, TZDate } from '@/app/_utils/tz'
 
 /**
  * ランキング用：指定 userIds の “現在の連続日数（current streak）” を一括算出
@@ -18,12 +17,11 @@ export async function getCurrentStreaksForUsers(
   if (!userIds || userIds.length === 0) return new Map<number, number>()
 
   // === JST の “今日 00:00” を UTC で求め、daysWindow 分さかのぼって下限を作る ===
-  const ZONE = 'Asia/Tokyo' as const
   const DAY_MS = 86_400_000
   const jstMidnightUtc = (utc: Date) => {
-    const t = new TZDateMini(utc, ZONE)
-    const m = new TZDateMini(t.getFullYear(), t.getMonth(), t.getDate(), 0, 0, 0, 0, ZONE)
-    return new Date(m.getTime())
+    const t = new TZDate(utc, TZ) // JSTの壁時計
+    const m = new TZDate(t.getFullYear(), t.getMonth(), t.getDate(), 0, 0, 0, 0, TZ)
+    return new Date(m.getTime()) // JST 00:00 に対応する実 UTC
   }
   const todayJstStartUtc = jstMidnightUtc(new Date())
   const sinceUtc = new Date(todayJstStartUtc.getTime() - (daysWindow - 1) * DAY_MS)

--- a/src/app/api/ranking/_time.ts
+++ b/src/app/api/ranking/_time.ts
@@ -1,6 +1,8 @@
 import { addDays, addMonths, addWeeks, startOfDay, startOfMonth, startOfWeek } from 'date-fns'
 import { fromZonedTime, toZonedTime } from 'date-fns-tz'
 
+import { TZ } from '@/app/_utils/tz'
+
 import type { DayWindow, MonthWindow, WeekWindow } from './_types'
 
 /**
@@ -8,7 +10,6 @@ import type { DayWindow, MonthWindow, WeekWindow } from './_types'
  * すべて UTC を基準に計算し、JST の日/週/月の境界を UTC 時刻として返します。
  * 半開区間 [start, end) 前提。
  */
-const TZ = 'Asia/Tokyo' as const
 
 /** JST の「その日の 00:00(JST)」を UTC へ変換して返す */
 function jstStartOfDayUTC(base: Date): Date {


### PR DESCRIPTION
## 背景
- `TZDateMini` と `TZDate` の併存、そして `'Asia/Tokyo'` の直書きが混在しており、可読性・再発防止の観点で課題があった
- 本プロジェクトの用途ではフォーマッタ等のフル機能は不要のため、軽量な `TZDateMini` ベースに統一する

## 目的
- タイムゾーン関連の**唯一の入口**を作り、API 利用を単純化
- 直 import/直書きの再発を Lint で防止

## 変更点（主な差分）
- 新規: `src/app/_utils/tz.ts`
  - `export { TZDateMini as TZDate } from '@date-fns/tz'`
  - `export const TZ = 'Asia/Tokyo' as const`
  - `export const toUTCDate = (tzLike: { getTime: () => number }) => new Date(tzLike.getTime())`
- Lint: `.eslintrc.json`
  - `no-restricted-imports` で `@date-fns/tz` の直 import を禁止（**tz.ts のみ overrides で許可**）
- 置換/修正:
  - `src/app/_server/streak.ts`
  - `src/app/api/ranking/_server/streak.ts`
  - `src/app/_utils/streakCalculator.ts`
  - `src/app/_utils/jstToUtcRange.ts`
  - `src/app/_utils/studyTimeHelpers.ts`
  - `src/app/api/ranking/_time.ts`（※後述の微修正あり）
- ポリシー:
  - 以後、`TZDate/TZ/toUTCDate` は **必ず** `@/app/_utils/tz` から import する

## 注意（微修正のお願い）
`src/app/api/ranking/_time.ts` で、`{ TZ }` を import 済みですが、**ファイル内に `const TZ = 'Asia/Tokyo' as const` が残っています**。  
この重複定義は **削除**してください。

```diff
- const TZ = 'Asia/Tokyo' as const
```

## 動作確認手順

### 1) 直 import / 直書きの検出（ラッパー除外）
```bash
# 直 import（ESM / require / dynamic import）
git grep -nE "^\s*import\s+[^;]*from\s+['\"]@date-fns/tz['\"]" -- 'src' ':!src/app/_utils/tz.ts'
git grep -nE "require\(['\"]@date-fns/tz['\"]\)" -- 'src' ':!src/app/_utils/tz.ts'
git grep -nE "import\(['\"]@date-fns/tz['\"]\)" -- 'src' ':!src/app/_utils/tz.ts'

# 直書きの TZ 文字列
git grep -nE "['\"]Asia/Tokyo['\"]" -- 'src' ':!src/app/_utils/tz.ts'
```

### 2) ESLint チェック
```bash
npx eslint "src/**/*.{ts,tsx}" -f unix | grep "no-restricted-imports" || echo "OK: no direct imports"
```
### 3) ビルド & テスト
```bash
npm run build
npm test
```

### 4) 回帰観点（JST 境界の挙動）
- 日跨ぎ：JST 23:59 → 00:00 で日次集計が期待通りに切り替わる
- 週区切り：JST 日曜 00:00 起点の週範囲が [start, end)（半開区間）で算出される
- Prisma I/O：UTC Date を渡している（toUTCDate() または new Date(tzLike.getTime()) を使用）

## 影響範囲
- タイムゾーン依存のユーティリティ  
  - ストリーク計算：`src/app/_utils/streakCalculator.ts`、`src/app/_server/streak.ts`、`src/app/api/ranking/_server/streak.ts`
  - JST の日/週/月範囲計算：`src/app/_utils/jstToUtcRange.ts`、`src/app/api/ranking/_time.ts`、`src/app/_utils/studyTimeHelpers.ts`
- 既存の公開 API は不変のため **破壊的変更なし**

## 再発防止
- `.eslintrc.json`  
  - `no-restricted-imports` で `@date-fns/tz` の **直 import を禁止**（`src/app/_utils/tz.ts` は `overrides` で許可）
- タイムゾーン文字列 `'Asia/Tokyo'` は **`TZ` 定数へ集約**（コメントは対象外）
- 以後、`TZDate` / `TZ` / `toUTCDate` は **必ず** `@/app/_utils/tz` から import

## レビュー観点
- すべての `TZDate` / `TZ` / `toUTCDate` が **`@/app/_utils/tz` 経由**で import されていること
- `src/app/api/ranking/_time.ts` の **`const TZ = 'Asia/Tokyo' as const` が削除**されていること（重複定義の解消）
- Prisma I/O に UTC `Date` を渡す際、`toUTCDate(tzLike)` または `new Date(tzLike.getTime())` を用いていること
- JST 境界（日/週/月）の範囲は **半開区間 `[start, end)`** 前提で一貫していること

## 参考
- 追加機能（表示用のフォーマッタ等）が将来必要になった場合は、同ラッパーから `TZDateFull` 等の別名再輸出を追加して利用する方針

