### PR TITLE
HomePage をセクションごとに分割して可読性を向上

### DIFF
--- a/src/app/_components/home/CTA.tsx
+++ b/src/app/_components/home/CTA.tsx
@@ -1,6 +1,5 @@
-'use client'
-
 import { Sparkles } from 'lucide-react'
+import Link from 'next/link'
 
 import { Button } from '@/app/_components/ui/button'
 
@@ -12,18 +11,22 @@ export const CTA = () => (
     </div>
 
     <div className='space-y-3'>
-      <Button className='w-full bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white py-4 text-lg font-medium'>
-        <Sparkles className='w-5 h-5 mr-2' />
-        無料で始める
-      </Button>
+      <Link href='/dashboard'>
+        <Button className='w-full bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white py-4 text-lg font-medium'>
+          <Sparkles className='w-5 h-5 mr-2' />
+          無料で始める
+        </Button>
+      </Link>
 
-      <Button
-        variant='outline'
-        className='w-full border-green-500 text-green-600 hover:bg-green-50 py-3 bg-transparent'
-        style={{ borderImage: 'linear-gradient(to right, #10b981, #059669) 1' }}
-      >
-        機能をもっと見る
-      </Button>
+      <Link href='/navigator'>
+        <Button
+          variant='outline'
+          className='w-full border-green-500 text-green-600 hover:bg-green-50 py-3 bg-transparent'
+          style={{ borderImage: 'linear-gradient(to right, #10b981, #059669) 1' }}
+        >
+          機能をもっと見る
+        </Button>
+      </Link>
     </div>
   </section>
 )

--- a/src/app/_components/home/Header.tsx
+++ b/src/app/_components/home/Header.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import Link from 'next/link'
+
 import { Button } from '@/app/_components/ui/button'
 
 import { ManaboIcon } from '../manabo-icon'
@@ -8,8 +10,11 @@ export const Header = () => (
   <header className='bg-white border-b px-4 py-4'>
     <div className='flex items-center justify-between'>
       <ManaboIcon size='lg' className='max-w-32 mr-3' />
-      <Button className='bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white'>
-        始める
+      <Button
+        asChild
+        className='bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white'
+      >
+        <Link href='/dashboard'>始める</Link>
       </Button>
     </div>
   </header>

--- a/src/app/_components/home/Header.tsx
+++ b/src/app/_components/home/Header.tsx
@@ -2,15 +2,12 @@
 
 import { Button } from '@/app/_components/ui/button'
 
+import { ManaboIcon } from '../manabo-icon'
+
 export const Header = () => (
   <header className='bg-white border-b px-4 py-4'>
     <div className='flex items-center justify-between'>
-      <div className='flex items-center space-x-3'>
-        <div className='w-10 h-10 bg-gradient-to-br from-green-400 to-emerald-600 rounded-2xl flex items-center justify-center'>
-          <span className='text-white font-bold text-lg'>M</span>
-        </div>
-        <h1 className='text-xl font-bold text-gray-900'>manabo</h1>
-      </div>
+      <ManaboIcon size='lg' className='max-w-32 mr-3' />
       <Button className='bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white'>
         始める
       </Button>

--- a/src/app/_components/home/Hero.tsx
+++ b/src/app/_components/home/Hero.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ArrowRight, BookOpen, Sparkles } from 'lucide-react'
+import Link from 'next/link'
 
 import { Button } from '@/app/_components/ui/button'
 
@@ -26,9 +27,14 @@ export const Hero = () => (
       </div>
     </div>
 
-    <Button className='bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white px-8 py-3 text-lg'>
-      無料で始める
-      <ArrowRight className='w-5 h-5 ml-2' />
+    <Button
+      asChild
+      className='bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white px-8 py-3 text-lg'
+    >
+      <Link href='/dashboard'>
+        無料で始める
+        <ArrowRight className='w-5 h-5 ml-2' aria-hidden />
+      </Link>
     </Button>
   </section>
 )


### PR DESCRIPTION
## 目的
HomePage をセクション単位に分割し、可読性と保守性を向上。

## 変更点
- `app/page.tsx` を構成のみの薄いコンポーネントに変更
- 追加: `_components/home/{Header,Hero,FeatureCards,GroupStudyCard,Testimonials,Highlights,CTA,GradientDefs}.tsx`

## 動作確認
- `npm run dev` で起動し、`/` にアクセス
- 各セクションが表示され、コンソールエラーがないことを確認
