### PR TITLE
chore(vercel): デプロイフロー整備＋ナビゲーション修正（CTA/Header/Hero）＆ Prisma 対応

### DIFF
--- a/.github/workflows/vercel-deploy-hook.yml
+++ b/.github/workflows/vercel-deploy-hook.yml
@@ -1,0 +1,18 @@
+name: Trigger Vercel Deploy Hook
+
+on:
+  push:
+    branches:
+      - develop # ← 監視したいブランチ（複数OK）
+    # （必要ならパスフィルタでモノレポ最適化）
+    # paths:
+    #   - 'apps/web/**'
+    #   - '!docs/**'
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call Vercel Deploy Hook
+        run: |
+          curl -X POST -fsS "${{ secrets.VERCEL_DEPLOY_HOOK_URL }}" -H 'Content-Type: application/json' -d '{}' || exit 1

--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@date-fns/tz": "^1.3.1",
     "@hookform/resolvers": "^5.1.1",
-    "@prisma/client": "^6.11.1",
+    "@prisma/client": "6.15.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-aspect-ratio": "^1.1.7",
@@ -87,7 +88,7 @@
     "jest-environment-jsdom": "^30.0.5",
     "postcss": "^8",
     "prettier": "^3.6.2",
-    "prisma": "^6.11.1",
+    "prisma": "6.15.0",
     "tailwindcss": "^3.4.1",
     "typescript": "5.8.3"
   }

--- a/src/app/_components/home/CTA.tsx
+++ b/src/app/_components/home/CTA.tsx
@@ -1,6 +1,5 @@
-'use client'
-
 import { Sparkles } from 'lucide-react'
+import Link from 'next/link'
 
 import { Button } from '@/app/_components/ui/button'
 
@@ -12,18 +11,22 @@ export const CTA = () => (
     </div>
 
     <div className='space-y-3'>
-      <Button className='w-full bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white py-4 text-lg font-medium'>
-        <Sparkles className='w-5 h-5 mr-2' />
-        無料で始める
-      </Button>
+      <Link href='/dashboard'>
+        <Button className='w-full bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white py-4 text-lg font-medium'>
+          <Sparkles className='w-5 h-5 mr-2' />
+          無料で始める
+        </Button>
+      </Link>
 
-      <Button
-        variant='outline'
-        className='w-full border-green-500 text-green-600 hover:bg-green-50 py-3 bg-transparent'
-        style={{ borderImage: 'linear-gradient(to right, #10b981, #059669) 1' }}
-      >
-        機能をもっと見る
-      </Button>
+      <Link href='/navigator'>
+        <Button
+          variant='outline'
+          className='w-full border-green-500 text-green-600 hover:bg-green-50 py-3 bg-transparent'
+          style={{ borderImage: 'linear-gradient(to right, #10b981, #059669) 1' }}
+        >
+          機能をもっと見る
+        </Button>
+      </Link>
     </div>
   </section>
 )

--- a/src/app/_components/home/Header.tsx
+++ b/src/app/_components/home/Header.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import Link from 'next/link'
+
 import { Button } from '@/app/_components/ui/button'
 
 import { ManaboIcon } from '../manabo-icon'
@@ -8,8 +10,11 @@ export const Header = () => (
   <header className='bg-white border-b px-4 py-4'>
     <div className='flex items-center justify-between'>
       <ManaboIcon size='lg' className='max-w-32 mr-3' />
-      <Button className='bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white'>
-        始める
+      <Button
+        asChild
+        className='bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white'
+      >
+        <Link href='/dashboard'>始める</Link>
       </Button>
     </div>
   </header>

--- a/src/app/_components/home/Header.tsx
+++ b/src/app/_components/home/Header.tsx
@@ -2,15 +2,12 @@
 
 import { Button } from '@/app/_components/ui/button'
 
+import { ManaboIcon } from '../manabo-icon'
+
 export const Header = () => (
   <header className='bg-white border-b px-4 py-4'>
     <div className='flex items-center justify-between'>
-      <div className='flex items-center space-x-3'>
-        <div className='w-10 h-10 bg-gradient-to-br from-green-400 to-emerald-600 rounded-2xl flex items-center justify-center'>
-          <span className='text-white font-bold text-lg'>M</span>
-        </div>
-        <h1 className='text-xl font-bold text-gray-900'>manabo</h1>
-      </div>
+      <ManaboIcon size='lg' className='max-w-32 mr-3' />
       <Button className='bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white'>
         始める
       </Button>

--- a/src/app/_components/home/Hero.tsx
+++ b/src/app/_components/home/Hero.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ArrowRight, BookOpen, Sparkles } from 'lucide-react'
+import Link from 'next/link'
 
 import { Button } from '@/app/_components/ui/button'
 
@@ -26,9 +27,14 @@ export const Hero = () => (
       </div>
     </div>
 
-    <Button className='bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white px-8 py-3 text-lg'>
-      無料で始める
-      <ArrowRight className='w-5 h-5 ml-2' />
+    <Button
+      asChild
+      className='bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white px-8 py-3 text-lg'
+    >
+      <Link href='/dashboard'>
+        無料で始める
+        <ArrowRight className='w-5 h-5 ml-2' aria-hidden />
+      </Link>
     </Button>
   </section>
 )

--- a/src/app/_hooks/useNavigation.ts
+++ b/src/app/_hooks/useNavigation.ts
@@ -4,7 +4,6 @@ type NavigationFunctions = {
   onNavigateToDashboard: () => void
   onNavigateToSignup: () => void
   onNavigateToPasswordReset: () => void
-  onNavigateToDashboard: () => void
   onBack: () => void
 }
 
@@ -31,7 +30,6 @@ export const useNavigation = (): NavigationFunctions => {
     onNavigateToDashboard,
     onNavigateToSignup,
     onNavigateToPasswordReset,
-    onNavigateToDashboard,
     onBack,
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import localFont from 'next/font/local'
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import './globals.css'
 import { ToastContainer } from 'react-toastify'
 
@@ -26,15 +26,23 @@ export const metadata: Metadata = {
     'manaboは、学習の記録・可視化・共有を通じて、あなたのモチベーション維持と成長をサポートします。',
 }
 
+type BodyStyle = CSSProperties & { '--bottom-nav-h': string }
+
 export default async function RootLayout({ children }: Readonly<{ children: ReactNode }>) {
   const user = await getCurrentUser()
 
+  const bodyStyle: BodyStyle = { '--bottom-nav-h': '56px' }
+
   return (
     <html lang='ja'>
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`} style={bodyStyle}>
         <UserProvider initialUser={user}>
-          {children}
-          <ToastContainer closeOnClick />
+          <main className='min-h-[100dvh] pb-[calc(var(--bottom-nav-h)+env(safe-area-inset-bottom))]'>
+            {children}
+          </main>
+
+          <ToastContainer closeOnClick newestOnTop />
+
           <BottomNavigation />
         </UserProvider>
       </body>


### PR DESCRIPTION
# chore(vercel): デプロイフロー整備＋ナビゲーション修正（CTA/Header/Hero）＆ Prisma 対応

## 🧾 概要
- Vercel デプロイを安定化するために **Deploy Hook を叩く GitHub Actions** を追加
- Vercel の依存キャッシュ対策として **Prisma Client を自動生成**（`postinstall: prisma generate`）
- **`@prisma/client` と `prisma` のバージョン整合**（6.15.0 に固定）
- ランディングの **CTA / Header / Hero のボタンを正規のリンク遷移に修正**
- `useNavigation` の **重複キー削除**（`no-dupe-keys` 解消）

---

## ✨ 変更点（Diff サマリ）
### 1) CI / Deploy
- `.github/workflows/vercel-deploy-hook.yml` を新規追加  
  - `develop` への push をトリガに **Vercel Deploy Hook** を起動  
  - `secrets.VERCEL_DEPLOY_HOOK_URL` を使用

### 2) Prisma / package.json
- `scripts.postinstall` に `prisma generate` を追加  
- `@prisma/client` を `6.15.0` に、`prisma` を `6.15.0` に固定（整合）  
- それ以外のスクリプトは維持

### 3) ランディング UI 遷移の正規化
- `src/app/_components/home/CTA.tsx`
  - Button を **`<Link>` でラップ**（`/dashboard`・`/navigator` へ遷移）
- `src/app/_components/home/Header.tsx`
  - `ManaboIcon` を使用
  - 「始める」ボタンを **`<Button asChild><Link .../></Button>`** に変更（`/dashboard`）
- `src/app/_components/home/Hero.tsx`
  - 「無料で始める」ボタンを **`<Button asChild><Link .../></Button>`** に変更（`/dashboard`）
  - `ArrowRight` に `aria-hidden` を付与

### 4) useNavigation の重複削除
- `src/app/_hooks/useNavigation.ts`
  - `type` と `return` オブジェクトの **`onNavigateToDashboard` 重複定義を削除**  
  - ESLint `no-dupe-keys` / TS 1117 を解消

---

## 🔧 技術的ポイント
- **Prisma × Vercel** で発生する「クライアント未生成」問題に対し、`postinstall` で毎回生成させることで解消  
- リンク遷移は **Next.js の `<Link>` を正として、ボタンは `asChild` でアクセシブルに**  
- 今後の ESLint 警告（`no-console` / import 周り）は別 PR で段階的に解消予定

---

## ✅ 動作確認
- [x] ローカルで `npm ci && npm run build` が成功する  
- [x] `npm run lint` でエラーが出ない（警告は現状維持）  
- [x] `/`（ランディング）から **「無料で始める」→ `/dashboard`** へ遷移できる  
- [x] Header の **「始める」→ `/dashboard`** へ遷移できる  
- [x] CTA の **「機能をもっと見る」→ `/navigator`** へ遷移できる  
- [x] `develop` へ push 時、Actions が Vercel Deploy Hook を叩く

---

## 🧩 影響範囲
- ランディング周辺 UI（CTA / Header / Hero）の遷移先  
- デプロイフロー（GitHub Actions 追加・Vercel 側 Hook URL 依存）  
- Prisma Client 生成タイミング（`postinstall`）

---

## 🔐 環境変数・Secrets
- GitHub Secrets: `VERCEL_DEPLOY_HOOK_URL` を設定済みであること

---

## 🔗 関連
- Issue: #90（Vercel ビルドエラー対応）  
  ※番号は実プロジェクトに合わせて修正ください

---

## 📝 メモ
- Prisma のバージョンは **`@prisma/client` と `prisma` を常に同一**に保つ方針  
- 今回は `6.15.0` に統一（必要に応じて上げる際も **同時に** 変更）

