### PR TITLE
chore(deps): npm dedupe 実行方法を修正し依存整理を正しく適用

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "swr": "^2.3.4",
         "tailwind-merge": "^3.3.1",
         "vaul": "^1.1.2",
-        "zod": "^3.25.6"
+        "zod": "3.25.76"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",
@@ -10714,13 +10714,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/pretty-format/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/prisma": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.15.0.tgz",
@@ -10888,11 +10881,10 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
-      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
-      "license": "MIT",
-      "peer": true
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "swr": "^2.3.4",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
-    "zod": "^3.25.6"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
- 誤って `npx npm-dedupe` を実行していた箇所を `npm dedupe` に修正
- node_modules / package-lock.json をクリア後に再インストール
- 依存関係の重複を正しく解消し、ビルド環境の安定性を向上